### PR TITLE
Update Django documentation links to version 4.0

### DIFF
--- a/content/understand-django/2020-04-02-templates-user-interfaces.md
+++ b/content/understand-django/2020-04-02-templates-user-interfaces.md
@@ -683,7 +683,7 @@ that can supercharge your UI.
 ## The Templates Toolbox
 
 The Django documentation includes
-a {{< extlink "https://docs.djangoproject.com/en/3.0/ref/templates/builtins/" "large set of built-in tags" >}}
+a {{< extlink "https://docs.djangoproject.com/en/4.0/ref/templates/builtins/" "large set of built-in tags" >}}
 that you can use
 in your projects.
 We aren't going to cover all of them,
@@ -823,7 +823,7 @@ in the context,
 you can use the `date` filter
 to control the format
 of the datetime.
-The `date` {{< extlink "https://docs.djangoproject.com/en/3.0/ref/templates/builtins/#date" "documentation" >}} shows
+The `date` {{< extlink "https://docs.djangoproject.com/en/4.0/ref/templates/builtins/#date" "documentation" >}} shows
 what options you can use
 to modify the format.
 
@@ -1032,7 +1032,7 @@ of custom tags
 in our examples.
 There are some more advanced custom tagging features
 which you can explore
-in the {{< extlink "https://docs.djangoproject.com/en/3.0/howto/custom-template-tags/" "Django custom template tags documentation" >}}.
+in the {{< extlink "https://docs.djangoproject.com/en/4.0/howto/custom-template-tags/" "Django custom template tags documentation" >}}.
 
 ## Summary
 


### PR DESCRIPTION
The links are still pointing to version 3.0 which is no longer supported. This pull request updates the links to the current stable version, which is 4.0.